### PR TITLE
Update linter.py for WIP as a warning

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -33,7 +33,7 @@ class Annotations(Linter):
 
     defaults = {
         '-errors:,': ['FIXME'],
-        '-warnings:,': ['NOTE', 'README', 'TODO', 'XXX', '@todo']
+        '-warnings:,': ['NOTE', 'README', 'TODO', '@todo', 'XXX', 'WIP']
     }
 
     def run(self, cmd, code):


### PR DESCRIPTION
Myself and a couple coworkers of mine tend to put a comment with WIP (short for Work In Progress) in our code. If it would be possible to add this in, that would be greatly appreciated.