### PR TITLE
Fix version check

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -12,7 +12,7 @@
 """This module exports the Annotations plugin class."""
 
 import re
-import SublimeLinter
+import SublimeLinter.lint
 
 if getattr(SublimeLinter.lint, 'VERSION', 3) > 3:
     from SublimeLinter.lint import const, Linter


### PR DESCRIPTION
Since annotations is usually the first plugin to load, `SublimeLinter.lint` potentially hasn't been imported yet and just importing `SublimeLinter` isn't enough.