### PR TITLE
Various improvements and cleanups

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -29,10 +29,10 @@ class Annotations(Linter):
 
     syntax = '*'
     cmd = None
-    regex = re.compile(r'^(?P<line>\d+):(?P<col>\d+): ((?P<warning>warning)|(?P<error>error)) (?P<message>.*)')
+    regex = re.compile(r'^(?P<line>\d+):(?P<col>\d+): (warning \((?P<warning>.+?)\)|error \((?P<error>.+?)\)): (?P<message>.*)')
 
     # We use this to do the matching
-    match_re = r'^.*?(?P<message>(?:(?P<warning>{warnings})|(?P<error>{errors})).*)'
+    match_re = r'^.*?(?:(?P<warning>{warnings})|(?P<error>{errors})):?\s*(?P<message>.*)'
 
     # We are only interested in comments
     selectors = {
@@ -81,16 +81,18 @@ class Annotations(Linter):
             match = match_regex.match(line)
 
             if match:
-                col = match.start('message')
+                col = match.start('error')
                 word = match.group('error')
-                message = match.group('message')
+                message = match.group('message') or '<no message>'
 
                 if word:
                     error_type = ERROR
                 else:
+                    col = match.start('warning')
                     word = match.group('warning')
                     error_type = WARNING
 
-                output.append('{}:{}: {} {}'.format(i + 1, col + 1, error_type, message))
+                output.append('{}:{}: {} ({}): {}'
+                              .format(i + 1, col + 1, error_type, word, message))
 
         return ''.join(output)

--- a/linter.py
+++ b/linter.py
@@ -34,7 +34,7 @@ class Annotations(Linter):
                        r' (?P<message>.*)')
 
     # We use this to do the matching
-    match_re = r'^.*?(?:(?P<warning>{warnings})|(?P<error>{errors})):?\s*(?P<message>.*)'
+    mark_regex_template = r'(?:(?P<warning>{warnings})|(?P<error>{errors})):?\s*(?P<message>.*)'
 
     # We are only interested in comments
     selectors = {
@@ -75,12 +75,12 @@ class Annotations(Linter):
 
             options[option] = '|'.join(values)
 
-        match_regex = re.compile(self.match_re.format_map(options))
+        mark_regex = re.compile(self.mark_regex_template.format_map(options))
 
         output = []
 
         for i, line in enumerate(code.splitlines()):
-            match = match_regex.match(line)
+            match = mark_regex.search(line)
 
             if match:
                 col = match.start('error')

--- a/linter.py
+++ b/linter.py
@@ -29,7 +29,9 @@ class Annotations(Linter):
 
     syntax = '*'
     cmd = None
-    regex = re.compile(r'^(?P<line>\d+):(?P<col>\d+): (warning \((?P<warning>.+?)\)|error \((?P<error>.+?)\)): (?P<message>.*)')
+    regex = re.compile(r'^(?P<line>\d+):(?P<col>\d+):'
+                       r' (warning \((?P<warning>.+?)\)|error \((?P<error>.+?)\)):'
+                       r' (?P<message>.*)')
 
     # We use this to do the matching
     match_re = r'^.*?(?:(?P<warning>{warnings})|(?P<error>{errors})):?\s*(?P<message>.*)'

--- a/linter.py
+++ b/linter.py
@@ -70,7 +70,7 @@ class Annotations(Linter):
         mark_regex = re.compile(self.mark_regex_template.format_map(options))
 
         output = []
-        regions = self.view.find_by_selector('comment')
+        regions = self.view.find_by_selector('comment - punctuation.definition.comment')
 
         for region in regions:
             region_offset = self.view.rowcol(region.a)

--- a/linter.py
+++ b/linter.py
@@ -83,7 +83,7 @@ class Annotations(Linter):
                 row = region_offset[0] + i
                 # Need to account for region column offset only in first row
                 col = match.start() + (region_offset[1] if i == 0 else 0)
-                message = match.group('message') or '<no message>'
+                message = match.group('message').strip() or '<no message>'
                 word = match.group('error')
                 if word:
                     error_type = ERROR

--- a/linter.py
+++ b/linter.py
@@ -97,4 +97,4 @@ class Annotations(Linter):
                 output.append('{}:{}: {} ({}): {}'
                               .format(i + 1, col + 1, error_type, word, message))
 
-        return ''.join(output)
+        return '\n'.join(output)


### PR DESCRIPTION
Changes this:

![](https://camo.githubusercontent.com/c5e79a356c79012fcd382752e70380ce82bde3d7/68747470733a2f2f78302e61742f6366612e706e67)

to this:

![](https://camo.githubusercontent.com/31c3a56293888905b6b861b894fc47e840121f70/68747470733a2f2f78302e61742f3574472e706e67)

---

**Update**: Now only uses one lint context for each view (instead of one per comment) and does not use `Linter.build_options` anymore.