### PR TITLE
Fix multiple lint problems per line

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -93,4 +93,4 @@ class Annotations(Linter):
 
                 output.append('{}:{}: {} {}'.format(i + 1, col + 1, error_type, message))
 
-        return ''.join(output)
+        return '\n'.join(output)


### PR DESCRIPTION
They just weren't joined properly, so only the first TODO mark
of a comment (or multiple adjacent line comments) was highlighted.