### PR TITLE
New option 'onlyStartsWith'

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -58,7 +58,8 @@ class Annotations(Linter):
             words = settings.get(option)
             options[option] = '|'.join(_escape_words(words))
 
-        mark_regex = re.compile(self.mark_regex_template.format_map(options))
+        template_prefix = r'^' if settings.get('onlyStartsWith', False) else r''
+        mark_regex = re.compile(template_prefix + self.mark_regex_template.format_map(options))
 
         output = []
         regions = self.view.find_by_selector('comment - punctuation.definition.comment')


### PR DESCRIPTION
Added ability to highlight annotations, only if pattern finded  in begin of line (so reject annotations, where any other symbol before pattern).

For example, with this setting, here
```python
import os

#FIXME test
# test FIXME test

```
only first annotation will be highlighted and second will be ignored.

This useful for custom patterns, which can be part of commented source.