### PR TITLE
Allow customizing the comment selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Additional SublimeLinter-annotations settings:
 
 |Setting|Description|
 |:------|:----------|
-|warnings|Comma-delimited list of words that will be highlighted as warnings.|
-|errors|Comma-delimited list of words that will be highlighted as errors.|
+|`warnings`|Comma-delimited list of words that will be highlighted as warnings.|
+|`errors`|Comma-delimited list of words that will be highlighted as errors.|
+|`infos`|Comma-delimited list of words that will be highlighted as infos.|
+|`comment_selector` (*advanced*)| A scope selector for regions that the word lists will be searched in.|
 
-You may provide a string with multiple words separated by commas or a list of strings. Matching is case-sensitive and matches whole words.
+Matching is case-sensitive and matches whole words.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Additional SublimeLinter-annotations settings:
 |`warnings`|Comma-delimited list of words that will be highlighted as warnings.|
 |`errors`|Comma-delimited list of words that will be highlighted as errors.|
 |`infos`|Comma-delimited list of words that will be highlighted as infos.|
-|`comment_selector` (*advanced*)| A scope selector for regions that the word lists will be searched in.|
+|`selector_` (*advanced*)| A scope selector for regions that the word lists will be searched in.|
 
 Matching is case-sensitive and matches whole words.
 

--- a/linter.py
+++ b/linter.py
@@ -52,7 +52,7 @@ class Annotations(Linter):
         'errors': ['FIXME', 'ERROR'],
         'warnings': ['TODO', '@todo', 'XXX', 'WIP', 'WARNING'],
         'infos': ['NOTE', 'README', 'INFO'],
-        'comment_selector': 'comment - punctuation.definition.comment',
+        'selector_': 'comment - punctuation.definition.comment',
     }
 
     def run(self, cmd, code):
@@ -64,7 +64,7 @@ class Annotations(Linter):
         mark_regex = re.compile(self.mark_regex_template.format_map(options))
 
         output = []
-        regions = self.view.find_by_selector(self.settings['comment_selector'])
+        regions = self.view.find_by_selector(self.settings['selector_'])
 
         for region in regions:
             region_offset = self.view.rowcol(region.a)

--- a/linter.py
+++ b/linter.py
@@ -52,6 +52,7 @@ class Annotations(Linter):
         'errors': ['FIXME', 'ERROR'],
         'warnings': ['TODO', '@todo', 'XXX', 'WIP', 'WARNING'],
         'infos': ['NOTE', 'README', 'INFO'],
+        'comment_selector': 'comment - punctuation.definition.comment',
     }
 
     def run(self, cmd, code):
@@ -63,7 +64,7 @@ class Annotations(Linter):
         mark_regex = re.compile(self.mark_regex_template.format_map(options))
 
         output = []
-        regions = self.view.find_by_selector('comment - punctuation.definition.comment')
+        regions = self.view.find_by_selector(self.settings['comment_selector'])
 
         for region in regions:
             region_offset = self.view.rowcol(region.a)

--- a/linter.py
+++ b/linter.py
@@ -50,9 +50,12 @@ class Annotations(Linter):
     defaults = {
         'selector': '',  # select all views
         'errors': ['FIXME', 'ERROR'],
-        'warnings': ['TODO', '@todo', 'XXX', 'WIP', 'WARNING'],
+        'warnings': [
+            'TODO', '@todo', 'XXX', 'WIP', 'WARNING',
+            'todo!',  # Rust macro
+        ],
         'infos': ['NOTE', 'README', 'INFO'],
-        'selector_': 'comment - punctuation.definition.comment',
+        'selector_': 'comment - punctuation.definition.comment, support.macro.rust',
     }
 
     def run(self, cmd, code):


### PR DESCRIPTION
This allows matching `todo!()` markers in Rust files, which is not a comment but instead a macro expansion, scoped as `support.macro.rust`.

![2021-12-19_16-59-41](https://user-images.githubusercontent.com/931051/146681668-ac531bfe-175f-4801-8aa5-d9a6b1e5bc77.png)

Also fix outdated documentation.