### PR TITLE
Implement `find_errors` and return `LintMatch`es directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Additional SublimeLinter-annotations settings:
 |`warnings`|Comma-delimited list of words that will be highlighted as warnings.|
 |`errors`|Comma-delimited list of words that will be highlighted as errors.|
 |`infos`|Comma-delimited list of words that will be highlighted as infos.|
+|`mark_message`|Whether the rest of the comment line should be marked or just the word.|
 |`selector_` (*advanced*)| A scope selector for regions that the word lists will be searched in.|
 
 Matching is case-sensitive and matches whole words.

--- a/linter.py
+++ b/linter.py
@@ -62,7 +62,7 @@ class Annotations(Linter):
         'selector_': 'comment - punctuation.definition.comment, support.macro.rust',
     }
 
-    def run(self, _cmd, _code):
+    def run(self, cmd, code):
         # type: (Union[List[str], None], str) -> Union[util.popen_output, str]
         # Override default and do nothing instead.
         return ''

--- a/linter.py
+++ b/linter.py
@@ -75,15 +75,18 @@ class Annotations(Linter):
         for region in regions:
             region_offset = self.view.rowcol(region.a)
             region_text = self.view.substr(region)
+            offset_until_line = region.a
             for i, line in enumerate(region_text.splitlines()):
                 match = mark_regex.search(line)
                 if not match:
+                    offset_until_line += len(line) + 1  # for \n
                     continue
 
                 row = region_offset[0] + i
                 # Need to account for region column offset only in first row
                 col = match.start() + (region_offset[1] if i == 0 else 0)
-                match_region = sublime.Region(region.a + match.start(), region.a + match.end())
+                match_region = sublime.Region(offset_until_line + match.start(),
+                                              offset_until_line + match.end())
                 message = match.group('message').strip() or '<no message>'
                 word = match.group('error')
                 if word:
@@ -110,5 +113,6 @@ class Annotations(Linter):
                     # panel_line=,
                     offending_text=word,
                 ))
+                offset_until_line += len(line) + 1  # for \n
 
         return output

--- a/linter.py
+++ b/linter.py
@@ -45,7 +45,6 @@ class Annotations(Linter):
     """Discovers and marks FIXME, NOTE, README, TODO, @todo, and XXX annotations."""
 
     cmd = None
-    line_col_base = (0, 0)
 
     # We use this to do the matching
     mark_regex_template = r'(?P<word>(?P<info>{infos})|(?P<warning>{warnings})|(?P<error>{errors})):?\s*(?P<message>.*)'

--- a/linter.py
+++ b/linter.py
@@ -13,7 +13,7 @@
 
 import re
 
-from SublimeLinter.lint import Linter, LintMatch, ERROR, WARNING
+from SublimeLinter.lint import Linter, LintMatch
 
 
 MYPY = False
@@ -86,10 +86,9 @@ class Annotations(Linter):
 
                 message = match.group('message').strip() or '<no message>'
                 word = match.group('word')
-                if match.group('error'):
-                    error_type = ERROR
-                elif match.group('warning'):
-                    error_type = WARNING
+                for error_type in ('error', 'warning'):
+                    if match.group(error_type):
+                        break
                 else:
                     error_type = 'info'
 

--- a/linter.py
+++ b/linter.py
@@ -11,7 +11,7 @@
 
 """This module exports the Annotations plugin class."""
 
-from itertools import accumulate as accumulate_, chain
+from itertools import accumulate, chain
 import re
 
 from SublimeLinter.lint import Linter, LintMatch
@@ -19,7 +19,7 @@ from SublimeLinter.lint import Linter, LintMatch
 
 MYPY = False
 if MYPY:
-    from typing import Iterable, Iterator, List, Union
+    from typing import Iterator, List, Union
     from SublimeLinter.lint import util
 
 
@@ -79,7 +79,7 @@ class Annotations(Linter):
         for region in regions:
             region_text = self.view.substr(region)
             lines = region_text.splitlines(keepends=True)
-            offsets = accumulate(map(len, lines), initial=region.a)
+            offsets = accumulate(chain([region.a], map(len, lines)))
             for line, offset in zip(lines, offsets):
                 match = mark_regex.search(line)
                 if not match:
@@ -99,11 +99,3 @@ class Annotations(Linter):
                     code=word,
                     message=message
                 )
-
-
-def accumulate(iterable, initial=None):
-    # type: (Iterable[int], int) -> Iterable[int]
-    if initial is None:
-        return accumulate_(iterable)
-    else:
-        return accumulate_(chain([initial], iterable))

--- a/linter.py
+++ b/linter.py
@@ -73,18 +73,14 @@ class Annotations(Linter):
         regions = self.view.find_by_selector(self.settings['selector_'])
 
         for region in regions:
-            region_offset = self.view.rowcol(region.a)
             region_text = self.view.substr(region)
             offset_until_line = region.a
-            for i, line in enumerate(region_text.splitlines()):
+            for line in region_text.splitlines():
                 match = mark_regex.search(line)
                 if not match:
                     offset_until_line += len(line) + 1  # for \n
                     continue
 
-                row = region_offset[0] + i
-                # Need to account for region column offset only in first row
-                col = match.start() + (region_offset[1] if i == 0 else 0)
                 match_region = sublime.Region(offset_until_line + match.start(),
                                               offset_until_line + match.end())
                 message = match.group('message').strip() or '<no message>'
@@ -99,6 +95,7 @@ class Annotations(Linter):
                         word = match.group('info')
                         error_type = 'info'
 
+                row, col = self.view.rowcol(match_region.a)
                 output.append(dict(
                     line=row,
                     start=col,

--- a/linter.py
+++ b/linter.py
@@ -86,11 +86,7 @@ class Annotations(Linter):
 
                 message = match.group('message').strip() or '<no message>'
                 word = match.group('word')
-                for error_type in ('error', 'warning'):
-                    if match.group(error_type):
-                        break
-                else:
-                    error_type = 'info'
+                error_type = next(et for et in ('error', 'warning', 'info') if match.group(et))
 
                 row, col = self.view.rowcol(offset_until_line + match.start())
                 text_to_mark = match.group() if self.settings.get('mark_message') else word

--- a/linter.py
+++ b/linter.py
@@ -86,10 +86,10 @@ class Annotations(Linter):
         for region in regions:
             region_text = self.view.substr(region)
             offset_until_line = region.a
-            for line in region_text.splitlines():
+            for line in region_text.splitlines(keepends=True):
                 match = mark_regex.search(line)
                 if not match:
-                    offset_until_line += len(line) + 1  # for \n
+                    offset_until_line += len(line)
                     continue
 
                 group = 0 if self.settings['mark_message'] else 'word'  # type: Union[int, str]
@@ -116,4 +116,4 @@ class Annotations(Linter):
                     msg=message,
                     offending_text=match.group(group),
                 )
-                offset_until_line += len(line) + 1  # for \n
+                offset_until_line += len(line)


### PR DESCRIPTION
Fixes #33 

Instead of creating and then parsing a string with a regular expression,
we can instead build and return a list of `LintMatch`es (a typed dict)
directly and skip some indirection.

~~I am not sure if `lint` is *supposed* to be overridden like this, but I
do remember advocating for it a couple years ago when the change for a
proper data structure for lint results was discussed. It just now
happened to be a convenient way to implement end markers for the
highlighted region.~~  (@kaste The implementation, the point to patch, has 
changed, `lint` is considered private)

In this particular instance, it allows us to specify a full region for
marking the error, where we now specify the entire match including the
remainder of the comment instead of just the trigger word. This can be
changed, of course, but I figured it wouldn't be a bad idea initially.

---

The motivation for this change was to allow for the trailing `!` mentioned in #34 to be marked, since it isn't a word character and thus wouldn't be picked up by the automatic region expansion from the marked character.

**Before** (#34)
![2021-12-19_17-02-29](https://user-images.githubusercontent.com/931051/146681775-b4448a75-3ea1-4e18-ae8a-c07270f5eba5.png)

**After** (with #34)
![2021-12-19_17-03-29](https://user-images.githubusercontent.com/931051/146681796-f5dd9399-8a2b-4df8-af82-26f9254fa6f3.png)

