### PR TITLE
Allow setting some error types to null or the empty list

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,8 +24,6 @@ if MYPY:
 
 
 def _escape_words(values):
-    if not values:
-        return
     for value in values:
         # Add \b word separator fences around the value
         # if it begins or ends with a word character.

--- a/linter.py
+++ b/linter.py
@@ -83,7 +83,6 @@ class Annotations(Linter):
         ))
 
         regions = self.view.find_by_selector(self.settings['selector_'])
-
         for region in regions:
             region_text = self.view.substr(region)
             lines = region_text.splitlines(keepends=True)

--- a/linter.py
+++ b/linter.py
@@ -96,9 +96,9 @@ class Annotations(Linter):
                 word = match.group('word')
                 match_groups = match.groupdict()
                 error_type = next(
-                    et
-                    for et in ('errors', 'warnings', 'infos')
-                    if et in match_groups
+                    error_type_
+                    for error_type_ in ('errors', 'warnings', 'infos')
+                    if error_type_ in match_groups
                 )
 
                 row, col = self.view.rowcol(offset + match.start())


### PR DESCRIPTION
Fixes #39

A user might want to disable our "infos".  Typically you would do so
by setting `"infos": null` or `"infos": []` but this was not supported.

Redo how we construct our regex and prohibit empty matching groups.